### PR TITLE
update controller module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ terraform.tfstate*
 .terraform
 crash.log
 .terraform.lock.hcl
-appgate.tfvars
+*auto.tfvars
+.plan

--- a/deployment/aws/README.md
+++ b/deployment/aws/README.md
@@ -45,3 +45,8 @@ Apply the rest of the resources once the controller is up and runnning.
 ```
 terraform apply -auto-approve
 ```
+
+
+## Initial Setup
+
+Default Admin UI login is `admin`/`admin`. You should change this immediately.

--- a/deployment/aws/controller/controller.tf
+++ b/deployment/aws/controller/controller.tf
@@ -26,14 +26,6 @@ resource "aws_instance" "appgate_controller" {
     device_name = "/dev/xvdb"
   }
 
-  connection {
-    type        = "ssh"
-    user        = "cz"
-    timeout     = "25m"
-    private_key = file(var.private_key)
-    host        = aws_instance.appgate_controller.public_ip
-  }
-
   # https://sdphelp.appgate.com/adminguide/v5.3/appliance-installation.html
   user_data_base64 = base64encode(local.controller_user_data)
 

--- a/deployment/aws/controller/data.tf
+++ b/deployment/aws/controller/data.tf
@@ -8,13 +8,13 @@ data "aws_ami" "appgate_ami" {
 
   # Product Codes
   # BYOL      2t5itl5x43ar3tljs7s2mu3rw
-  # Licensed  2oiadaeqo2k6kdw1pgflzxkfd
+  # Licensed  cbse92jrh5o5yi82s7eub483b
 
   filter {
     name = "product-code"
     values = [lower(var.licensing_type) == "byol" ?
       "2t5itl5x43ar3tljs7s2mu3rw" : # byol
-      "2oiadaeqo2k6kdw1pgflzxkfd"   # licensed
+      "cbse92jrh5o5yi82s7eub483b"   # licensed
     ]
   }
 

--- a/deployment/aws/controller/data.tf
+++ b/deployment/aws/controller/data.tf
@@ -40,7 +40,7 @@ cz-seed \
     --enable-logserver \
     --no-registration \
     --hostname "$PUBLIC_HOSTNAME" \
+    --admin-password ${var.admin_login_password} \
     | jq '.remote.adminInterface.hostname = .remote.peerInterface.hostname | .remote.adminInterface.allowSources = .remote.peerInterface.allowSources' >> /home/cz/seed.json
-
 EOF
 }

--- a/deployment/aws/controller/data.tf
+++ b/deployment/aws/controller/data.tf
@@ -1,0 +1,46 @@
+data "aws_ami" "appgate_ami" {
+  owners = ["679593333241"] # Appgate
+
+  filter {
+    name   = "name"
+    values = ["*${var.appgate_version}*"]
+  }
+
+  # Product Codes
+  # BYOL      2t5itl5x43ar3tljs7s2mu3rw
+  # Licensed  2oiadaeqo2k6kdw1pgflzxkfd
+
+  filter {
+    name = "product-code"
+    values = [lower(var.licensing_type) == "byol" ?
+      "2t5itl5x43ar3tljs7s2mu3rw" : # byol
+      "2oiadaeqo2k6kdw1pgflzxkfd"   # licensed
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+locals {
+  controller_user_data = <<-EOF
+#!/bin/bash
+PUBLIC_HOSTNAME=`curl --silent http://169.254.169.254/latest/meta-data/public-hostname`
+# seed the first controller, and enable admin interface on :8443
+cz-seed \
+    --password cz cz \
+    --dhcp-ipv4 eth0 \
+    --enable-logserver \
+    --no-registration \
+    --hostname "$PUBLIC_HOSTNAME" \
+    | jq '.remote.adminInterface.hostname = .remote.peerInterface.hostname | .remote.adminInterface.allowSources = .remote.peerInterface.allowSources' >> /home/cz/seed.json
+
+EOF
+}

--- a/deployment/aws/controller/network.tf
+++ b/deployment/aws/controller/network.tf
@@ -1,5 +1,5 @@
 resource "aws_subnet" "appgate_appliance_subnet" {
-  count = var.subnet_id == "" ? 1 : 0
+  count      = var.subnet_id == "" ? 1 : 0
   vpc_id     = var.vpc_id
   cidr_block = var.appliance_cidr_block
 
@@ -9,7 +9,7 @@ resource "aws_subnet" "appgate_appliance_subnet" {
 }
 
 resource "aws_security_group" "appgate_security_group" {
-  count = var.security_group == "" ? 1 : 0
+  count       = var.security_group == "" ? 1 : 0
   description = "Security group used by Appgate."
   vpc_id      = var.vpc_id
 
@@ -64,8 +64,8 @@ resource "aws_route_table" "appgate_route_table" {
 
 
 resource "aws_key_pair" "deployer" {
-  count = var.aws_key_pair_name == "" ? 1 : 0
-  key_name_prefix   = "appgate-demo-deployer-key"
-  public_key = file(var.public_key)
-  tags       = var.common_tags
+  count           = var.aws_key_pair_name == "" ? 1 : 0
+  key_name_prefix = "appgate-demo-deployer-key"
+  public_key      = file(var.public_key)
+  tags            = var.common_tags
 }

--- a/deployment/aws/controller/network.tf
+++ b/deployment/aws/controller/network.tf
@@ -1,4 +1,5 @@
 resource "aws_subnet" "appgate_appliance_subnet" {
+  count = var.subnet_id == "" ? 1 : 0
   vpc_id     = var.vpc_id
   cidr_block = var.appliance_cidr_block
 
@@ -8,6 +9,7 @@ resource "aws_subnet" "appgate_appliance_subnet" {
 }
 
 resource "aws_security_group" "appgate_security_group" {
+  count = var.security_group == "" ? 1 : 0
   description = "Security group used by Appgate."
   vpc_id      = var.vpc_id
 
@@ -42,7 +44,7 @@ resource "aws_security_group" "appgate_security_group" {
 }
 
 resource "aws_route_table_association" "appgate_route_table_assoication" {
-  subnet_id      = aws_subnet.appgate_appliance_subnet.id
+  subnet_id      = aws_subnet.appgate_appliance_subnet[0].id
   route_table_id = aws_route_table.appgate_route_table.id
 }
 
@@ -62,7 +64,8 @@ resource "aws_route_table" "appgate_route_table" {
 
 
 resource "aws_key_pair" "deployer" {
-  key_name   = "appgate-demo-deployer-key"
+  count = var.aws_key_pair_name == "" ? 1 : 0
+  key_name_prefix   = "appgate-demo-deployer-key"
   public_key = file(var.public_key)
   tags       = var.common_tags
 }

--- a/deployment/aws/controller/variables.tf
+++ b/deployment/aws/controller/variables.tf
@@ -78,3 +78,9 @@ variable "appgate_version" {
     error_message = "ERROR must be a semantic version (string)."
   }
 }
+
+variable "admin_login_password" {
+  type = string
+  default = "admin"
+  sensitive = true
+}

--- a/deployment/aws/controller/variables.tf
+++ b/deployment/aws/controller/variables.tf
@@ -1,17 +1,80 @@
 
 variable "aws_region" {}
-variable "appgate_ami" {}
-variable "subnet_id" {}
-variable "security_group" {}
-variable "controller_instance_type" {}
-variable "private_key" {}
-variable "public_key" {}
-variable "aws_key_pair_name" {}
-variable "common_tags" {}
+variable "appgate_ami" {
+  type = string
+  description = "Prefer to ignore: Consider using the appgate_version + licensing_type parameters to locate your AMI. Only specify if you want to override AMI looking."
+  default = ""
+}
+variable "subnet_id" {
+  type = string
+  default = ""
+  description = "if blank, will create a security group"
+}
+variable "security_group" {
+  type = string
+  default = ""
+  description = "if blank, will create a security group"
+}
+variable "controller_instance_type" {
+  default     = "t2.small"
+  type        = string
+  description = "Size of instance to deploy. Vendor recommends c5.xlarge"
+  # options: 
+  # t2/3. micro, medium, large
+  # c4/5. xlarge, 2xlarge, 4xlarge
+  # c5.large
+  # m4/5. large, xlarge, 2xlarge, 4xlarge
+  # r4. large,xlarge
+  validation {
+    condition     = can(regex("(t(2|3)\\.(small|medium|large)|c(4|5)\\.(|2|4)xlarge|c5.large|m(4|5)\\.(|x|2x|4x)large|r4\\.(|x)large)", var.controller_instance_type))
+    error_message = "ERROR Must be a valid instance size, see variable description."
+  }
+}
+
+variable "private_key" {
+  type = string
+  description = "location of the private key you want to use to administer"
+}
+variable "public_key" {
+  type = string
+  description = "location of the public key"
+}
+variable "aws_key_pair_name" {
+  default = ""
+  description = "public key to set on ASG instances. If one does not previously exist, leave blank and fill in var.public_key"
+}
+variable "common_tags" {
+  type = map
+  default = {}
+}
 
 
 # Network related variables
 variable "vpc_id" {}
 variable "appliance_cidr_block" {}
-variable "ingress_cidr_blocks" {}
+variable "ingress_cidr_blocks" {
+  type = list
+}
 variable "internet_gateway_id" {}
+
+variable "licensing_type" {
+  type        = string
+  description = "Valid Values: byol or licensed. Whether or not to use a bring your own license or prelicensed AMI."
+  default     = "byol"
+  validation {
+    condition     = lower(var.licensing_type) == "byol" || lower(var.licensing_type) == "licensed"
+    error_message = "ERROR Valid value options: byol, licensed."
+  }
+}
+
+variable "appgate_version" {
+  type        = string
+  default     = "5.3.2" # latest
+  description = "semantic version of the version of appgate you want to install. will search for an AMI matching this semver"
+  validation {
+    # Regex for valid semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    condition = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+    var.appgate_version))
+    error_message = "ERROR must be a semantic version (string)."
+  }
+}

--- a/deployment/aws/controller/variables.tf
+++ b/deployment/aws/controller/variables.tf
@@ -1,18 +1,18 @@
 
 variable "aws_region" {}
 variable "appgate_ami" {
-  type = string
+  type        = string
   description = "Prefer to ignore: Consider using the appgate_version + licensing_type parameters to locate your AMI. Only specify if you want to override AMI looking."
-  default = ""
+  default     = ""
 }
 variable "subnet_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "if blank, will create a security group"
 }
 variable "security_group" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "if blank, will create a security group"
 }
 variable "controller_instance_type" {
@@ -32,19 +32,19 @@ variable "controller_instance_type" {
 }
 
 variable "private_key" {
-  type = string
+  type        = string
   description = "location of the private key you want to use to administer"
 }
 variable "public_key" {
-  type = string
+  type        = string
   description = "location of the public key"
 }
 variable "aws_key_pair_name" {
-  default = ""
+  default     = ""
   description = "public key to set on ASG instances. If one does not previously exist, leave blank and fill in var.public_key"
 }
 variable "common_tags" {
-  type = map
+  type    = map(any)
   default = {}
 }
 
@@ -53,7 +53,7 @@ variable "common_tags" {
 variable "vpc_id" {}
 variable "appliance_cidr_block" {}
 variable "ingress_cidr_blocks" {
-  type = list
+  type = list(any)
 }
 variable "internet_gateway_id" {}
 
@@ -80,7 +80,7 @@ variable "appgate_version" {
 }
 
 variable "admin_login_password" {
-  type = string
-  default = "admin"
+  type      = string
+  default   = "admin"
   sensitive = true
 }


### PR DESCRIPTION
This PR provides:

- ami search by product code and allowing for version locking. you can still specify an AMI but i find it much easier to also allow for a search based on version + licensing type. ~**note** i have only been using BYOL. i attempted to determine which product code to use for licensed but **you should definitely confirm that i used the correct product code**~ using the hardcoded ami name i referenced the product_code in aws and used that. options are `byol` ami or `-PAID` license (what you had previously)
- count has been applied to conditionally created resources
- count logic is more straightforward using`==` instead of `!=`
- if keypair is created we now use `key_name_prefix` to allow for better use of tf workspaces
- added more variable defaults to make deploys easier
- added variable validation for variables that can fail during apply due to vendor specs. attempted to link to vendor docs where applicable
- allow user to define default admin password

*note* the `[0]` on some resources is required because we provided a `count` on the parent resource.

i have another update coming for gateway but i didnt want to overwhelm